### PR TITLE
docs: add missing working memory tool deploy step to README on trip planner example

### DIFF
--- a/examples/amazon-bedrock-multi-agent-collaboration/trip_planner_agent/README.md
+++ b/examples/amazon-bedrock-multi-agent-collaboration/trip_planner_agent/README.md
@@ -24,6 +24,10 @@ pip3 install -r src/requirements.txt
 
 Follow instructions [here](/src/shared/web_search/).
 
+3. Deploy Working Memory tool
+
+Follow instructions [here](/src/shared/working_memory/).
+
 ## Usage & Sample Prompts
 
 1. Deploy Amazon Bedrock Agents


### PR DESCRIPTION
The previous version of the README omitted working tool deployment step, leading to agent invocation error.

*Issue #, if available:*
Agent invocation breaks as the agent is not able to access the missing working memory tool Lambda function.

*Description of changes:*
Added the deployment step to the documentation. Deploying the working memory tool solves the agent invocation error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
