### PR TITLE
Fix/remove redundant session state validation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,4 +19,4 @@
 - [Tony Santiago](https://github.com/tsanti)
 - [Aswath Ram A. Srinivasan](https://github.com/aswathsr101)
 - [Lucas Banerji](https://github.com/LucaiB)
-
+- [Renya Kujirada](https://github.com/ren8k)

--- a/src/InlineAgent/src/InlineAgent/agent/inline_agent.py
+++ b/src/InlineAgent/src/InlineAgent/agent/inline_agent.py
@@ -222,13 +222,6 @@ class InlineAgent:
             session_state = {}
 
         print(f"SessionId: {session_id}")
-        if "returnControlInvocationResults" in session_state:
-            raise ValueError(
-                "returnControlInvocationResults key is not supported in inlineSessionState"
-            )
-
-        if "invocationId" in session_state:
-            raise ValueError("invocationId key is not supported in inlineSessionState")
 
         agent_answer = ""
 


### PR DESCRIPTION
# Inline Agent SDK: Remove session state validation checks to enable manual RoC processing workflows

<!-- Do not erase any parts of this template not applicable to your Pull Request. -->
<!-- If a section does not apply to you, provide reasoning. -->

## Instructions

- Do not erase any parts of this template that are not applicable to your pull request.
- If a section is not applicable, explicitly state the reason.
- * [x] Tick the checkboxes for the items you have completed.
- These are mandatory requirements, not mere suggestions.

<hr/>

## Describe your changes

* [x] Concise description of the PR

```
Changes to InlineAgent.invoke method by removing validation checks that block valid session state usage patterns. This change allows for manual processing of Return of Control events when using process_response=False, enabling legitimate asynchronous workflows with the library.
```

<hr/>

## Issue ticket number and link

* [ ] Issue # (if applicable)

Not applicable. This change addresses an API inconsistency that prevents a valid use case.

<hr/>

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/awslabs/amazon-bedrock-agent-samples/pulls) for the same update/change?
* [ ] Are you uploading a dataset?
* [ ] Have you added contributions to [RELEASE NOTES](/RELEASE_NOTES.md)?

<hr/>

### New Example Submissions:

* [ ] Have you tested your code, and made sure the functionality runs successfully? Provide screenshots. 
* [ ] Have you linted your Python code with [black](https://github.com/psf/black)?
* [ ] Does this implementation use the shared tools `src/utils/*`. List them here:

```
1. web_search
2. ...
```

* [ ] Does this implementation use the helper functions `src/utils/*`. List them here:

```
1. bedrock_agent_helper.py
2. ...
```

* [ ] Have you included your Agent Example name and introduction in [README.md](/README.md) and [examples/agents/README.md](/examples/agents/README.md)?
* [ ] Have you included your Multi-Agent Example name and introduction in [README.md](/README.md) and [examples/multi_agent_collaboration/README.md](/examples/multi_agent_collaboration/README.md)?
* [ ] Have you documented **Introduction**, **Architecture Diagram**, **Prerequisites**, **Usage**, **Sample Prompts**, and **Clean Up** steps in your example README?
* [ ] I agree to resolve any [issues](https://github.com/awslabs/amazon-bedrock-agent-samples/issues) created for this example in the future.

<hr/>

### src/utils Submissions:

Changes to the utils folder won't be accepted. Instead, open a new [issue](https://github.com/awslabs/amazon-bedrock-agent-samples/issues).

<hr/>

### src/shared tool Submissions:

Changes to existing tools won't be accepted. Instead, open a new [issue](https://github.com/awslabs/amazon-bedrock-agent-samples/issues).

* [ ] Business justification for including a new tool

```
This tool is necessary because ...
```

* How is this tool implemented?
    - * [ ] AWS CDK
    - * [ ] AWS CloudFormation (recommended)

<hr/>

* [x] Add your name to [CONTRIBUTORS.md](/CONTRIBUTORS.md) :D

<hr/>

## Technical Details
The PR removes the following validation checks from inline_agent.py:

```py
if "returnControlInvocationResults" in session_state:
    raise ValueError(
        "returnControlInvocationResults key is not supported in inlineSessionState"
    )

if "invocationId" in session_state:
    raise ValueError("invocationId key is not supported in inlineSessionState")
```

## Rationale

- The invoke method supports a process_response=False parameter which returns the raw response for manual processing.
- When manually processing events, it's common to handle Return of Control (RoC) events using ProcessROC.process_roc.
- The output of process_roc includes session state information needed for subsequent calls.
- The current validation rejects session state that comes from process_roc, breaking this valid workflow.
- Since the library already supports this pattern with its API design, these validation checks contradict that intent.

This change enables proper manual event processing workflows while still maintaining the library's intended functionality.

## Sample code

```py
import asyncio

from InlineAgent.action_group import ActionGroup
from InlineAgent.agent import InlineAgent
from InlineAgent.agent.process_roc import ProcessROC


# Step 1: Define tools with Docstring
def get_current_weather(location: str, state: str, unit: str = "fahrenheit") -> dict:
    """
    Get the current weather in a given location.

    Parameters:
        location: The city, e.g., San Francisco
        state: The state eg CA
        unit: The unit to use, e.g., fahrenheit or celsius. Defaults to "fahrenheit"
    """
    return "Weather is 70 fahrenheit"


# Step 2: Logically group tools together
weather_action_group = ActionGroup(
    name="WeatherActionGroup",
    description="This is action group to get weather",
    tools=[get_current_weather],
)

# Step 3: Define agent
agent = InlineAgent(
    foundation_model="us.anthropic.claude-3-5-haiku-20241022-v1:0",
    instruction="You are a friendly assistant that is responsible for getting the current weather.",
    action_groups=[weather_action_group],
    agent_name="MockAgent",
)


# Step 4: Invoke agent
async def main():
    agent_answer = ""
    session_id = "123"
    session_state = {}

    while not agent_answer:
        response = await agent.invoke(
            input_text="What is the weather of NY? ",
            session_id=session_id,
            session_state=session_state,
            process_response=False,
        )

        event_stream = response["completion"]
        for event in event_stream:
            print("=== Event Stream ===")
            print(event)
            print("========================")
            if "returnControl" in event:
                session_state = await ProcessROC.process_roc(
                    inlineSessionState={},
                    roc_event=event["returnControl"],
                    tool_map=agent.tool_map,
                )
                print("=== Session State ===")
                print(session_state)
                print("========================")
            # Get Final Answer
            if "chunk" in event:
                agent_answer = event["chunk"]["bytes"].decode("utf8")
                print("=== Agent Answer ===")
                print(agent_answer)
                print("========================")
                break

    return agent_answer


if __name__ == "__main__":
    result = asyncio.run(main())
    print("\nFinal Answer:", result)

```