### PR TITLE
Skip TSTALIASID during cleanup

### DIFF
--- a/src/utils/bedrock_agent_helper.py
+++ b/src/utils/bedrock_agent_helper.py
@@ -605,7 +605,6 @@ class AgentsForAmazonBedrock:
         # Delete the agent aliases
         if _target_agent is not None:
             _agent_id = _target_agent["agentId"]
-
             if verbose:
                 print(f"Deleting aliases for agent {_agent_id}...")
 
@@ -615,6 +614,8 @@ class AgentsForAmazonBedrock:
                 )
                 for alias in _agent_aliases["agentAliasSummaries"]:
                     alias_id = alias["agentAliasId"]
+                    if alias_id == "TSTALIASID":
+                        continue
                     print(f"Deleting alias {alias_id} from agent {_agent_id}")
                     response = self._bedrock_agent_client.delete_agent_alias(
                         agentAliasId=alias_id, agentId=_agent_id


### PR DESCRIPTION
# Skip TSTALIASID during cleanup

<!-- Do not erase any parts of this template not applicable to your Pull Request. -->
<!-- If a section does not apply to you, provide reasoning. -->

<hr/>

## Describe your changes

When running through the hello world multi-agent collaboration example, clean-up fails due to presence of the test alias:

```
Error deleting aliases: An error occurred (ValidationException) when calling the DeleteAgentAlias operation: 1 validation error detected: Value 'TSTALIASID' at 'agentAliasId' failed to satisfy constraint: Member must satisfy regular expression pattern: (?!\bTSTALIASID\b)[0-9a-zA-Z]+
```

<hr/>

## Issue ticket number and link

* [x] Issue #137

<hr/>

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/awslabs/amazon-bedrock-agent-samples/pulls) for the same update/change?
* [ ] Are you uploading a dataset?
* [ ] Have you added contributions to [RELEASE NOTES](/RELEASE_NOTES.md)?
